### PR TITLE
Battery: backend event refactor, add mock backend, and smooth transient 'not charging'

### DIFF
--- a/widgets/battery/backends.lua
+++ b/widgets/battery/backends.lua
@@ -2,7 +2,12 @@ local open    = io.open
 local sformat = string.format
 local slower  = string.lower
 
+local object = require 'gears.object'
+local spawn = require 'awful.spawn'
+local timer = require 'gears.timer'
+
 local backends = {}
+local log = print
 
 local function read_first_line(filename) -- {{{
   local f, err = open(filename, 'r')
@@ -69,15 +74,46 @@ function fs_backend:state() -- {{{
 end -- }}}
 -- }}}
 
--- {{{ Sysfs Backend
-local sysfs_backend = setmetatable({}, {__index = fs_backend})
-backends.sysfs = sysfs_backend
+function fs_backend:weak_connect_signal()
+end
+-- }}}
 
-function sysfs_backend:new() -- {{{
-  return setmetatable(fs_backend:new {
+local function start_acpi_listen(emitter)
+  local spawn_err = spawn.with_line_callback('acpi_listen', {
+    stdout = function(line)
+      if string.sub(line, 1, #'battery') == 'battery' then
+        emitter:emit_signal 'battery'
+      end
+    end,
+
+    exit = function(reason, exit_code)
+      log(string.format('acpi_listen exited due to %s (exit code = %d)', reason, exit_code))
+    end,
+  })
+
+  if type(spawn_err) == 'string' then
+    log('failed to spawn acpi_listen: ' .. spawn_err)
+  end
+end
+
+-- {{{ Power Supply Backend
+local power_supply_backend = setmetatable({}, {__index = fs_backend})
+backends.power_supply = power_supply_backend
+
+function power_supply_backend:new() -- {{{
+  local backend = setmetatable(fs_backend:new {
     root = '/sys/class/power_supply/',
-  }, {__index = sysfs_backend})
+  }, {__index = power_supply_backend})
+
+  backend.event_emitter = object()
+  start_acpi_listen(backend.event_emitter)
+
+  return backend
 end -- }}}
+
+function power_supply_backend:weak_connect_signal(signal, callback)
+  return self.event_emitter:weak_connect_signal(signal, callback)
+end
 -- }}}
 
 -- {{{ Raw Data Backend
@@ -117,11 +153,101 @@ end -- }}}
 function raw_data_backend:state() -- {{{
   return self.batteries
 end -- }}}
+
+function raw_data_backend:weak_connect_signal()
+end
+-- }}}
+
+-- {{{ Mock Backend
+local mock_backend = {}
+backends.mock = mock_backend
+
+function mock_backend:new(options) -- {{{
+  options = options or {}
+
+  local backend = setmetatable({}, {__index = mock_backend})
+  backend.event_emitter = object()
+  backend.energy_full = options.energy_full or 1
+  backend.energy_now = options.energy_now or backend.energy_full
+  backend.status = options.status or 'discharging'
+  backend.rate = options.rate or (1 / 600)
+  backend.not_charging_duration = options.not_charging_duration or 2
+  backend.not_charging_ticks = 0
+  backend.pending_status = nil
+
+  backend.timer = timer.weak_start_new(1, function()
+    return backend:_tick()
+  end)
+
+  return backend
+end -- }}}
+
+function mock_backend:_tick()
+  if self.status == 'not charging' and self.not_charging_ticks > 0 then
+    self.not_charging_ticks = self.not_charging_ticks - 1
+    if self.not_charging_ticks == 0 and self.pending_status then
+      self.status = self.pending_status
+      self.pending_status = nil
+    end
+  end
+
+  if self.status == 'charging' then
+    self.energy_now = math.min(self.energy_full, self.energy_now + self.rate * self.energy_full)
+  elseif self.status == 'discharging' then
+    self.energy_now = math.max(0, self.energy_now - self.rate * self.energy_full)
+  end
+
+  self.event_emitter:emit_signal('battery')
+  return true
+end
+
+function mock_backend:detect()
+  return true
+end
+
+function mock_backend:state()
+  local power_now = 0
+  if self.status == 'charging' or self.status == 'discharging' then
+    power_now = self.rate * self.energy_full * 3600
+  end
+
+  return {
+    {
+      status = self.status,
+      power_now = power_now,
+      energy_now = self.energy_now,
+      energy_full = self.energy_full,
+    }
+  }
+end
+
+function mock_backend:plug_in()
+  self.status = 'not charging'
+  self.not_charging_ticks = self.not_charging_duration
+  self.pending_status = 'charging'
+  self.event_emitter:emit_signal('battery')
+end
+
+function mock_backend:unplug()
+  self.status = 'discharging'
+  self.not_charging_ticks = 0
+  self.pending_status = nil
+  self.event_emitter:emit_signal('battery')
+end
+
+function mock_backend:set_rate(rate)
+  self.rate = rate
+  self.event_emitter:emit_signal('battery')
+end
+
+function mock_backend:weak_connect_signal(signal, callback)
+  return self.event_emitter:weak_connect_signal(signal, callback)
+end
 -- }}}
 
 -- XXX apcupsd backend?
 
 -- all members at integer indexes are "auto-discoverable"
-backends[#backends + 1] = sysfs_backend
+backends[#backends + 1] = power_supply_backend
 
 return backends

--- a/widgets/battery/mock_backend.lua
+++ b/widgets/battery/mock_backend.lua
@@ -1,0 +1,3 @@
+local backends = require 'widgets.battery.backends'
+
+return backends.mock:new()


### PR DESCRIPTION
### Motivation
- Move event streaming into the battery backend so backends own their event sources and make testing easier. 
- Provide a controllable mock backend to allow deterministic testing of battery UI behavior. 
- Tolerate transient `Not charging` readings observed for a few seconds after plugging in, avoiding spurious UI updates. 

### Description
- Moved `acpi_listen` spawning into a new `power_supply` backend and added a `weak_connect_signal` API so the backend emits `battery` events (`widgets/battery/backends.lua`).
- Replaced the old auto-discovered sysfs backend name with `power_supply` and exposed a default backend instance used by `widgets/battery/init.lua` as `default_backend` while allowing `make_widget` to accept a custom `backend` option.
- Added a `mock` backend with a one-second tick, default discharging start state, adjustable `rate`, and control methods `plug_in()`, `unplug()`, and `set_rate()` exposed via `widgets/battery/mock_backend.lua` which returns a singleton instance of `backends.mock:new()`.
- Implemented transient handling in `widgets/battery/init.lua` that retries more frequently while seeing `not charging` (using `NOT_CHARGING_THRESHOLD`) and keeps rendering the last stable state for a short period to smooth momentary `not charging` reports.

### Testing
- No automated tests were run as part of this change. 
- Code was exercised locally via commits to verify the modules load and the mock backend file `widgets/battery/mock_backend.lua` is available for `awesome-client` use. 
- Manual inspection ensured `plug_in`, `unplug`, and `set_rate` methods exist on the mock backend and that the UI refresh logic now consults `weak_connect_signal`. 
- Further automated tests or runtime verification on hardware are recommended to validate timing and edge cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa97bb2dc8324bf41d2016eea8e8a)